### PR TITLE
Update entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,7 +7,7 @@ COLOR_YELLOW='\033[1;33m'
 COLOR_OFF='\033[0m'
 
 if [[ -z "${DEP_PATH}" ]]; then
-  DEP_PATH="./requirenments.txt"
+  DEP_PATH="./requirements.txt"
 else
   DEP_PATH="${DEP_PATH}"
 fi


### PR DESCRIPTION
The extra 'n' character causes errors when the requirements file is not specified, and the container will fail and not start.