### PR TITLE
Mauricelambert patch pip vulnerability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Container image that runs your code
-FROM python:3.11.9
+FROM python:latest
 
 # Install python safety package
 RUN pip install --upgrade pip && pip install safety

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # Container image that runs your code
-FROM python:3-buster
+FROM python:3.11.9
 
 # Install python safety package
-RUN pip install safety
+RUN pip install --upgrade pip && pip install safety
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
I get the following output when i run this action:

```
+==============================================================================+
 VULNERABILITIES REPORTED 
+==============================================================================+

-> Vulnerability found in pip version 23.1.2
   Vulnerability ID: 62044
   Affected spec: <23.3
   ADVISORY: Pip 23.3 includes a fix for CVE-2023-5752: When
   installing a package from a Mercurial VCS URL (ie "pip install hg+...")...
   CVE-2023-5752
   For more information about this vulnerability, visit
   https://data.safetycli.com/v/62044/97c
   To ignore this vulnerability, use PyUp vulnerability id 62044 in safety’s
   ignore command-line argument or add the ignore to your safety policy file.


+==============================================================================+
   REMEDIATIONS

  1 vulnerability was reported in 1 package. For detailed remediation & fix 
  recommendations, upgrade to a commercial license. 

+==============================================================================+
```

To fix it:
 - i change the docker image to use stable version for python and debian instead of debian 10
 - i force pip upgrade in the docker file